### PR TITLE
merge

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,37 @@
-on: [push, pull_request, workflow_dispatch]
+name: Build ZMK Firmware
+
+on:
+  push:
+    branches:
+      - master
+      - sofle_hybrid_rgb_rev5
+  workflow_dispatch:
+
+permissions:
+  contents: write
 
 jobs:
   build:
     uses: zmkfirmware/zmk/.github/workflows/build-user-config.yml@main
+
+  create_release_master:
+    if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download firmware artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: firmware
+
+      - name: Get current date
+        id: date
+        run: echo "date=$(date +'%Y-%m-%d')" >> $GITHUB_OUTPUT
+
+      - name: Create Release with firmware
+        uses: softprops/action-gh-release@v1
+        with:
+          tag_name: ${{ steps.date.outputs.date }}-${{ github.sha }}
+          name: Firmware ${{ steps.date.outputs.date }} - master
+          body: Build from commit ${{ github.sha }}
+          files: '*.uf2'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ permissions:
 
 jobs:
   build:
-    uses: zmkfirmware/zmk/.github/workflows/build-user-config.yml@main
+    uses: zmkfirmware/zmk/.github/workflows/build-user-config.yml@v0.3
 
   create_release_master:
     if: github.event_name == 'push' && github.ref == 'refs/heads/master'

--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+[![Build Status](../../actions/workflows/build.yml/badge.svg)](../../actions)
+[![Download Firmware](https://img.shields.io/badge/Download-Firmware-blue?logo=github)](../../releases/latest)
+
 # Sofle V2 Keyboard Guide
 This guide is for flashing the Ergomech Sofle V2 Keyboard. The Sofle V2 is 6×4+5 keys column-staggered split keyboard, using Cherry switches.
 

--- a/build.yaml
+++ b/build.yaml
@@ -13,11 +13,11 @@
 #
 ---
 include:
-  - board: nice_nano_v2
+  - board: bluemicro840_v1
     shield: sofle_left
     snippet: studio-rpc-usb-uart
     cmake-args: -DCONFIG_ZMK_STUDIO=y
-  - board: nice_nano_v2
+  - board: bluemicro840_v1
     shield: sofle_right
-  - board: nice_nano_v2
+  - board: bluemicro840_v1
     shield: settings_reset

--- a/build.yaml
+++ b/build.yaml
@@ -15,6 +15,8 @@
 include:
   - board: nice_nano_v2
     shield: sofle_left
+    snippet: studio-rpc-usb-uart
+    cmake-args: -DCONFIG_ZMK_STUDIO=y
   - board: nice_nano_v2
     shield: sofle_right
   - board: nice_nano_v2

--- a/build.yaml
+++ b/build.yaml
@@ -13,11 +13,11 @@
 #
 ---
 include:
-  - board: bluemicro840_v1
+  - board: nice_nano_v2
     shield: sofle_left
     snippet: studio-rpc-usb-uart
     cmake-args: -DCONFIG_ZMK_STUDIO=y
-  - board: bluemicro840_v1
+  - board: nice_nano_v2
     shield: sofle_right
-  - board: bluemicro840_v1
+  - board: nice_nano_v2
     shield: settings_reset

--- a/config/sofle.conf
+++ b/config/sofle.conf
@@ -15,3 +15,4 @@ CONFIG_ZMK_RGB_UNDERGLOW=y
 # By default toggling the underglow on and off also toggles external power
 # on and off. This also causes the display to turn off.
 CONFIG_ZMK_RGB_UNDERGLOW_EXT_POWER=n
+CONFIG_ZMK_STUDIO_LOCKING=n

--- a/config/sofle.conf
+++ b/config/sofle.conf
@@ -9,7 +9,7 @@ CONFIG_EC11=y
 CONFIG_EC11_TRIGGER_GLOBAL_THREAD=y
 
 # Uncomment this line below to add rgb underglow / backlight support
-CONFIG_ZMK_RGB_UNDERGLOW=y
+#CONFIG_ZMK_RGB_UNDERGLOW=y
 
 # Uncomment the line below to disable external power toggling by the underglow.
 # By default toggling the underglow on and off also toggles external power

--- a/config/sofle.keymap
+++ b/config/sofle.keymap
@@ -67,7 +67,7 @@
 &kp GRAVE  &kp N1     &kp N2     &kp N3       &kp N4    &kp N5                       &kp N6     &kp N7    &kp N8           &kp N9     &kp N0    &kp F12
 &trans     &kp EXCL   &kp AT     &kp HASH     &kp DLLR  &kp PRCNT                    &kp CARET  &kp AMPS  &kp KP_MULTIPLY  &kp LPAR   &kp RPAR  &kp PIPE
 &trans     &kp EQUAL  &kp MINUS  &kp KP_PLUS  &kp LBRC  &kp RBRC   &trans    &trans  &kp LBKT   &kp RBKT  &kp SEMI         &kp COLON  &kp BSLH  &trans
-                      &trans     &trans       &trans    &trans     &trans    &trans  &trans     &trans    &trans           &trans
+                      &studio_unlock     &trans       &trans    &trans     &trans    &trans  &trans     &trans    &trans           &trans
             >;
 
             sensor-bindings = <&inc_dec_kp C_VOL_UP C_VOL_DN &inc_dec_kp PG_UP PG_DN>;

--- a/config/sofle.keymap
+++ b/config/sofle.keymap
@@ -63,7 +63,7 @@
             //               |     |      |      |      |        |  |       |      |       |       |      |
 
             bindings = <
-&trans     &kp F1     &kp F2     &kp F3       &kp F4    &kp F5                       &kp F6     &kp F7    &kp F8           &kp F9     &kp F10   &kp F11
+&studio_unlock     &kp F1     &kp F2     &kp F3       &kp F4    &kp F5                       &kp F6     &kp F7    &kp F8           &kp F9     &kp F10   &kp F11
 &kp GRAVE  &kp N1     &kp N2     &kp N3       &kp N4    &kp N5                       &kp N6     &kp N7    &kp N8           &kp N9     &kp N0    &kp F12
 &trans     &kp EXCL   &kp AT     &kp HASH     &kp DLLR  &kp PRCNT                    &kp CARET  &kp AMPS  &kp KP_MULTIPLY  &kp LPAR   &kp RPAR  &kp PIPE
 &trans     &kp EQUAL  &kp MINUS  &kp KP_PLUS  &kp LBRC  &kp RBRC   &trans    &trans  &kp LBKT   &kp RBKT  &kp SEMI         &kp COLON  &kp BSLH  &trans

--- a/config/west.yml
+++ b/config/west.yml
@@ -5,7 +5,7 @@ manifest:
   projects:
     - name: zmk
       remote: zmkfirmware
-      revision: main
+      revision: v0.3
       import: app/west.yml
   self:
     path: config

--- a/keymap-drawer/sofle.svg
+++ b/keymap-drawer/sofle.svg
@@ -577,9 +577,9 @@ path.combo {
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>
 <text x="0" y="0" class="key trans tap">▽</text>
 </g>
-<g transform="translate(140, 259)" class="key trans keypos-50">
-<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>
-<text x="0" y="0" class="key trans tap">▽</text>
+<g transform="translate(140, 259)" class="key keypos-50">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+<text x="0" y="0" class="key tap"><tspan style="font-size: 64%">&amp;studio_un…</tspan></text>
 </g>
 <g transform="translate(196, 252)" class="key trans keypos-51">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>

--- a/keymap-drawer/sofle.svg
+++ b/keymap-drawer/sofle.svg
@@ -67,8 +67,8 @@ text.footer {
     paint-order: stroke;
 }
 
-/* styling for combo tap, and key hold/shifted label text */
-text.combo, text.hold, text.shifted {
+/* styling for combo tap, and key non-tap label text */
+text.combo, text.hold, text.shifted, text.left, text.right {
     font-size: 11px;
 }
 
@@ -82,12 +82,20 @@ text.shifted {
     dominant-baseline: hanging;
 }
 
+text.left {
+    text-anchor: start;
+}
+
+text.right {
+    text-anchor: end;
+}
+
 text.layer-activator {
     text-decoration: underline;
 }
 
 /* styling for hold/shifted label text in combo box */
-text.combo.hold, text.combo.shifted {
+text.combo.hold, text.combo.shifted, text.combo.left, text.combo.right {
     font-size: 8px;
 }
 
@@ -365,9 +373,9 @@ path.combo {
 <g transform="translate(30, 398)" class="layer-lower">
 <text x="0" y="28" class="label" id="lower">lower:</text>
 <g transform="translate(0, 56)">
-<g transform="translate(28, 63)" class="key trans keypos-0">
-<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>
-<text x="0" y="0" class="key trans tap">▽</text>
+<g transform="translate(28, 63)" class="key keypos-0">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+<text x="0" y="0" class="key tap"><tspan style="font-size: 64%">&amp;studio_un…</tspan></text>
 </g>
 <g transform="translate(84, 63)" class="key keypos-1">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>

--- a/keymap-drawer/sofle.yaml
+++ b/keymap-drawer/sofle.yaml
@@ -3,7 +3,7 @@ layers:
   default: ['`', '1', '2', '3', '4', '5', '6', '7', '8', '9', '0', DELETE, ESC, Q, W, E, R, T, Y, U, I, O, P, BSPC, TAB, A, S, D, F, G, H, J, K, L, ;, '''', LSHFT,
     Z, X, C, V, B, MUTE, '', N, M, ',', ., /, RSHFT, LGUI, LALT, LCTRL, lower, RET, SPACE, raise, RCTRL, RALT, RGUI]
   lower:
-  - {t: ▽, type: trans}
+  - '&studio_unlock'
   - F1
   - F2
   - F3

--- a/keymap-drawer/sofle.yaml
+++ b/keymap-drawer/sofle.yaml
@@ -1,4 +1,4 @@
-layout: {qmk_keyboard: sofle/rev1}
+layout: {zmk_keyboard: sofle}
 layers:
   default: ['`', '1', '2', '3', '4', '5', '6', '7', '8', '9', '0', DELETE, ESC, Q, W, E, R, T, Y, U, I, O, P, BSPC, TAB, A, S, D, F, G, H, J, K, L, ;, '''', LSHFT,
     Z, X, C, V, B, MUTE, '', N, M, ',', ., /, RSHFT, LGUI, LALT, LCTRL, lower, RET, SPACE, raise, RCTRL, RALT, RGUI]
@@ -53,7 +53,7 @@ layers:
   - ':'
   - \
   - {t: ▽, type: trans}
-  - {t: ▽, type: trans}
+  - '&studio_unlock'
   - {t: ▽, type: trans}
   - {t: ▽, type: trans}
   - {type: held}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Enable ZMK Studio in build and config, add `&studio_unlock` on the lower layer, and update keymap-drawer assets and styling accordingly.
> 
> - **Build/Config**:
>   - Enable ZMK Studio for `nice_nano_v2 + sofle_left` (`snippet: studio-rpc-usb-uart`, `-DCONFIG_ZMK_STUDIO=y`).
>   - Add `CONFIG_ZMK_STUDIO_LOCKING=n`.
>   - Comment out `CONFIG_ZMK_RGB_UNDERGLOW`.
> - **Keymap (`config/sofle.keymap`)**:
>   - Add `&studio_unlock` on the lower layer (top-left key and left thumb position) replacing `&trans`.
> - **Keymap Drawer**:
>   - Switch layout to `{zmk_keyboard: sofle}`.
>   - Reflect `&studio_unlock` in `lower` layer (`keymap-drawer/sofle.yaml`, `sofle.svg`).
>   - Extend SVG text classes to include `text.left` and `text.right` and apply to combo label sizing.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fb224a7a6b595957c12a2c58537c4f07f19f9b8b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->